### PR TITLE
Busca de dados no banco concluída.

### DIFF
--- a/src/repositories/raw_repository.py
+++ b/src/repositories/raw_repository.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from sqlalchemy.dialects.postgresql import insert
 from src.database import SessionLocal
 from src.repositories.raw import RawVitiviniculturaCurrent
-
+from sqlalchemy import select
 class RawRepository:
     def upsert(
         self,
@@ -11,6 +11,18 @@ class RawRepository:
         subopcao: str | None,
         payload: dict
     ) -> None:
+        """
+        Insere ou atualiza (upsert) um registro na tabela raw_vitivinicultura.
+
+        Se já existir um registro com a mesma chave primária (endpoint, ano, subopcao),
+        os campos 'payload' e 'fetched_at' serão atualizados.
+
+        Parâmetros:
+            endpoint (str): Nome do endpoint (ex: 'comercializacao', 'producao').
+            ano (int): Ano dos dados.
+            subopcao (str | None): Subcategoria opcional. Usa string vazia se None.
+            payload (dict): Dados a serem armazenados no formato JSON.
+        """
         pk_sub = subopcao if subopcao is not None else ""
         insert_stmt = insert(RawVitiviniculturaCurrent).values(
             endpoint=endpoint,
@@ -31,3 +43,35 @@ class RawRepository:
         with SessionLocal() as session:
             session.execute(upsert_stmt)
             session.commit()
+
+    def get(
+        self,
+        endpoint: str,
+        ano: int,
+        subopcao: str | None
+    ) -> dict | None:
+        """
+        Busca um registro da tabela raw_vitivinicultura com base nos filtros fornecidos.
+
+        Parâmetros:
+            endpoint (str): Nome do endpoint (ex: 'comercializacao', 'producao').
+            ano (int): Ano dos dados.
+            subopcao (str | None): Subcategoria opcional. Usa string vazia se None.
+
+        Retorna:
+            dict | None: O conteúdo armazenado em 'payload' se encontrado, caso contrário None.
+        """
+        try:
+            pk_sub = subopcao or ""
+            with SessionLocal() as session:
+                stmt = select(RawVitiviniculturaCurrent).filter_by(
+                    endpoint=endpoint,
+                    ano=ano,
+                    subopcao=pk_sub
+                )
+                row = session.execute(stmt).scalars().first()
+                return row.payload if row else None
+        except Exception as e:
+            print(f"Erro ao buscar dados do banco: {e}")
+            return None
+

--- a/src/services/comercializacao_services.py
+++ b/src/services/comercializacao_services.py
@@ -1,7 +1,6 @@
 """Service para comercialização de vinhos, sucos e derivados
 do Rio Grande do Sul."""
 from src.raspagem.comercializacao_raspagem import ComercializacoRaspagem
-from src.repositories.comercializacao_repository import ComercializacaoRepository
 from src.repositories.raw_repository import RawRepository
 
 class ComercializacaoService:
@@ -12,26 +11,36 @@ class ComercializacaoService:
 
     def __init__(self):
         self._repo_raw = RawRepository()
-        self.comercializacao_repository = ComercializacaoRepository()
 
     def get_por_ano(self, ano: int):
         """
         Retorna a comercialização de vinhos, sucos e derivados
         do Rio Grande do Sul por ano.
+        Tenta raspar; em falha, retorna o que estiver salvo.
         """
         try:
             comercializacao_raspagem = ComercializacoRaspagem(ano)
             comercializacao_raspagem.buscar_html()
             dados = comercializacao_raspagem.parser_html()
 
-            self._repo_raw.upsert(
-                endpoint="comercializacao",
-                ano=ano,
-                subopcao=None,
-                payload=dados
-            )
-            
-            self.comercializacao_repository.salvar_ou_atualizar(dados, ano)
+            if dados:
+                self._repo_raw.upsert(
+                    endpoint="comercializacao",
+                    ano=ano,
+                    subopcao=None,
+                    payload=dados
+                )
+                return {"source": "site", "data": dados}
+ 
         except Exception:
-            print("Erro ao buscar dados")
-        return self.comercializacao_repository.get_por_ano(ano)
+            pass
+
+        """
+        Fallback: busca no banco
+        """
+        dados_banco = self._repo_raw.get(
+            endpoint="comercializacao",
+            ano=ano,
+            subopcao=None
+        )
+        return {"source": "banco", "data": dados_banco}

--- a/src/services/importacao_service.py
+++ b/src/services/importacao_service.py
@@ -1,6 +1,5 @@
 """Service para importação de vinhos, sucos e derivados
     do Rio Grande do Sul."""
-from src.repositories.importacao_repository import ImportacaoRepository
 from src.raspagem.importacao_raspagem import ImportacaoRaspagem
 from src.repositories.raw_repository import RawRepository
 
@@ -10,23 +9,34 @@ class ImportacaoService:
 
     def __init__(self):
         self._repo_raw = RawRepository()
-        self.importacao_repository = ImportacaoRepository()
 
     def get_por_ano(self, ano: int, subopcao: str):
-        """Retorna a importação de vinhos, sucos e derivados"""
+        """
+        Retorna a importação de vinhos, sucos e derivados
+        Tenta raspar; em falha, retorna o que estiver salvo.
+        """
         try:
             importacao_raspagem = ImportacaoRaspagem(ano, subopcao)
             importacao_raspagem.buscar_html()
             dados = importacao_raspagem.parser_html()
   
-            self._repo_raw.upsert(
-                endpoint="importacao",
-                ano=ano,
-                subopcao=subopcao,
-                payload=dados
-            )
-
-            self.importacao_repository.salvar_ou_atualizar(dados, ano, subopcao)
+            if dados:
+                self._repo_raw.upsert(
+                    endpoint="importacao",
+                    ano=ano,
+                    subopcao=subopcao,
+                    payload=dados
+                )
+                return {"source": "site", "data": dados}
+            
         except Exception:
-            print("Erro ao buscar dados")
-        return self.importacao_repository.get_por_ano(ano, subopcao)
+            pass
+        """
+        Fallback: busca no banco
+        """
+        dados_banco = self._repo_raw.get(
+            endpoint="importacao",
+            ano=ano,
+            subopcao=subopcao
+        )
+        return {"source": "banco", "data": dados_banco}

--- a/src/services/producao_services.py
+++ b/src/services/producao_services.py
@@ -1,12 +1,7 @@
-"""
-Service para Produção de vinhos, sucos e derivados
-do Rio Grande do Sul.
-"""
-
+""" Service para Produção de vinhos, sucos e derivados
+do Rio Grande do Sul. """
 from src.raspagem.producao_raspagem import ProducaoRaspagem
-from src.repositories.producao_repository import ProducaoRepository
 from src.repositories.raw_repository import RawRepository
-
 
 class ProducaoService:
     """
@@ -16,26 +11,36 @@ class ProducaoService:
 
     def __init__(self):
         self._repo_raw = RawRepository()
-        self.producao_repository = ProducaoRepository()
 
     def get_por_ano(self, ano: int):
         """
         Retorna a produção de vinhos, sucos e derivados
         do Rio Grande do Sul por ano.
+        Tenta raspar; em falha, retorna o que estiver salvo.
         """
         try:
             producao_raspagem = ProducaoRaspagem(ano)
             producao_raspagem.buscar_html()
             dados = producao_raspagem.parser_html()
   
-            self._repo_raw.upsert(
-                endpoint="producao",
-                ano=ano,
-                subopcao=None,
-                payload=dados
-            )
+            if dados:
+                self._repo_raw.upsert(
+                    endpoint="producao",
+                    ano=ano,
+                    subopcao=None,
+                    payload=dados
+                )
+                return {"source": "site", "data": dados}
 
-            self.producao_repository.salvar_ou_atualizar(dados, ano)
         except Exception:
-            print("Erro ao buscar dados")
-        return self.producao_repository.get_por_ano(ano)
+            pass
+
+        """
+        Fallback: busca no banco
+        """
+        dados_banco = self._repo_raw.get(
+            endpoint="producao",
+            ano=ano,
+            subopcao=None
+        )
+        return {"source": "banco", "data": dados_banco}


### PR DESCRIPTION

1. **Padrão unificado de fallback “scraping → banco”**

   * Em todos os *services* de cada categoria (Comercialização, Exportação, Importação, Processamento e Produção), o fluxo de obtenção dos dados passou a ser:

     1. **Tentar** rodar o scraper (`*Raspagem`)
     2. Se **não gerar dados** ou lançar exceção, **buscar** o payload previamente salvo no Postgres

2. **Inclusão de `source` na resposta de cada Service**

   * Ao retornar, cada *service* entrega um objeto com:

     * `source`: `"site"` (quando veio do scraper) ou `"banco"` (quando veio do PostgreSQL)
     * `data`: o JSON de payload

3. **Novo método `RawRepository.get()`**

   * Criado em `raw_repository.py` para consultar a tabela `raw_vitivinicultura` pelo PK (`endpoint`, `ano`, `subopcao`) e retornar somente o campo `payload`.

4. **Uso de `RawRepository.upsert()` mantido para escrita**

   * Nos cinco *services*, ao obter dados via scraping, confirma-se o **upsert** para armazenar ou atualizar o registro no banco.

5. **Manutenção de nomes públicos**

   * Não houve alteração em assinaturas, nomes de métodos ou rotas da API; apenas se estendeu a resposta com o campo `source`.

6. **Serviços afetados**

   * `ComercializacaoService`
   * `ExportacaoService`
   * `ImportacaoService`
   * `ProcessamentoService`
   * `ProducaoService`

