### PR TITLE
Documentação da API com Swagger e Pydantic (#60)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from src.config.logging_config import configurar_logging
+
+configurar_logging()

--- a/src/filters/ano_subopcao_param.py
+++ b/src/filters/ano_subopcao_param.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel
-from pydantic import Field
-from typing import Literal
 from fastapi import Query
+from pydantic import BaseModel, Field
+from typing import Literal
+
 
 class AnoSubopcaoImportacaoFilterParams(BaseModel):
     """

--- a/src/main.py
+++ b/src/main.py
@@ -1,43 +1,37 @@
-"""Controller para os endpoints da aplicação"""
-
+from fastapi import HTTPException, Query
+from http import HTTPStatus
 from typing import Annotated
-from fastapi import Query
-from fastapi import HTTPException
 
-from src.config import app
-from src.config import URL_BASE
-from src.services.importacao_service import ImportacaoService
-from src.services.exportacao_service import ExportacaoService
-from src.services.producao_service import ProducaoService
-from src.services.comercializacao_service import ComercializacaoService
-from src.services.processamento_service import ProcessamentoService
-from src.filters.ano_filter_params import AnoVitiviniculturaFilterParams
-from src.filters.ano_subopcao_param import AnoSubopcaoProcessamentoFilterParams
-from src.filters.ano_subopcao_param import AnoSubopcaoImportacaoFilterParams
-from src.filters.ano_subopcao_param import AnoSubopcaoExportacaoFilterParams
+from src.config import app, URL_BASE
 from src.config.logging_config import configurar_logging
 
-configurar_logging()
+from src.filters.ano_filter_params import AnoVitiviniculturaFilterParams
+from src.filters.ano_subopcao_param import (AnoSubopcaoExportacaoFilterParams,
+                                            AnoSubopcaoImportacaoFilterParams,
+                                            AnoSubopcaoProcessamentoFilterParams)
+
+from src.services.comercializacao_service import ComercializacaoService
+from src.services.exportacao_service import ExportacaoService
+from src.services.importacao_service import ImportacaoService
+from src.services.processamento_service import ProcessamentoService
+from src.services.producao_service import ProducaoService
+
+from src.schemas import ProducaoResponse
+
+# configurar_logging()
+
+T_AnoFilter = Annotated[AnoVitiviniculturaFilterParams, Query()]
 
 
-@app.get(URL_BASE + "/producao")
-async def producao(
-    ano_filter: Annotated[
-        AnoVitiviniculturaFilterParams,
-        Query(
-            description="""Ano de produção dos vinhos, 
-              sucos e derivados do Rio Grande do Sul."""
-        ),
-    ],
-):
+@app.get(URL_BASE + "/producao", response_model=ProducaoResponse)
+async def producao(ano_filter: T_AnoFilter):
     """
-    Endpoint para retornar a produção de vinhos,
-    sucos e derivados do Rio Grande do Sul.
+    Endpoint para retornar a produção de vinhos, sucos e derivados do Rio Grande do Sul.
     """
     try:
         return ProducaoService().get_por_ano(ano_filter.ano)
     except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))
 
 
 @app.get(URL_BASE + "/comercializacao")

--- a/src/main.py
+++ b/src/main.py
@@ -3,24 +3,28 @@ from http import HTTPStatus
 from typing import Annotated
 
 from src.config import app, URL_BASE
-from src.config.logging_config import configurar_logging
-
 from src.filters.ano_filter_params import AnoVitiviniculturaFilterParams
 from src.filters.ano_subopcao_param import (AnoSubopcaoExportacaoFilterParams,
                                             AnoSubopcaoImportacaoFilterParams,
                                             AnoSubopcaoProcessamentoFilterParams)
-
+                         
 from src.services.comercializacao_service import ComercializacaoService
 from src.services.exportacao_service import ExportacaoService
 from src.services.importacao_service import ImportacaoService
 from src.services.processamento_service import ProcessamentoService
 from src.services.producao_service import ProducaoService
 
-from src.schemas import ProducaoResponse
+from src.schemas.comercializacao_schema import ComercializacaoResponse
+from src.schemas.exportacao_schema import ExportacaoResponse
+from src.schemas.importacao_schema import ImportacaoResponse
+from src.schemas.processamento_schema import ProcessamentoResponse
+from src.schemas.producao_schema import ProducaoResponse
 
-# configurar_logging()
 
 T_AnoFilter = Annotated[AnoVitiviniculturaFilterParams, Query()]
+T_AnoSubopcaoExportacaoFilter = Annotated[AnoSubopcaoExportacaoFilterParams, Query()]
+T_AnoSubopcaoImportacaoFilter = Annotated[AnoSubopcaoImportacaoFilterParams, Query()]
+T_AnoSubopcaoProcessamentoFilter = Annotated[AnoSubopcaoProcessamentoFilterParams, Query()]
 
 
 @app.get(URL_BASE + "/producao", response_model=ProducaoResponse)
@@ -34,52 +38,33 @@ async def producao(ano_filter: T_AnoFilter):
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))
 
 
-@app.get(URL_BASE + "/comercializacao")
-async def comercializacao(
-    ano_filter: Annotated[
-        AnoVitiviniculturaFilterParams,
-        Query(
-            description="""Ano de comercialização dos vinhos, 
-              sucos e derivados do Rio Grande do Sul."""
-        ),
-    ],
-):
+@app.get(URL_BASE + "/comercializacao", response_model=ComercializacaoResponse)
+async def comercializacao(ano_filter: T_AnoFilter):
     """
-    Endpoint para retornar a comercialização de vinhos,
-    sucos e derivados do Rio Grande do Sul.
+    Endpoint para retornar a comercialização de vinhos, sucos e derivados do Rio Grande do Sul.
     """
     try:
         return ComercializacaoService().get_por_ano(ano_filter.ano)
     except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))
 
-@app.get(URL_BASE + "/processamento")
-async def processamento(
-    params: Annotated[
-        AnoSubopcaoProcessamentoFilterParams,
-        Query(
-            description="""Endpoint para retornar os dados de 
-            processamento de uvas viníferas, americanas, de mesa 
-            e sem classificação no Rio Grande do Sul."""
-        ),
-    ],
-):
+
+@app.get(URL_BASE + "/processamento", response_model=ProcessamentoResponse)
+async def processamento(ano_subopcao_filter: T_AnoSubopcaoProcessamentoFilter):
     """
     Endpoint para retornar os dados de processamento de uvas viníferas, 
     americanas, de mesa e sem classificação no Rio Grande do Sul.
     """
     try:
-        return ProcessamentoService().get_por_ano(params.ano, params.subopcao)
+        return ProcessamentoService().get_por_ano(
+            ano_subopcao_filter.ano, ano_subopcao_filter.subopcao
+        )
     except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        raise HTTPException(status_code=404, detail=str(e))
 
-@app.get(URL_BASE + "/importacao")
-async def importacao(
-    ano_subopcao_filter: Annotated[
-        AnoSubopcaoImportacaoFilterParams,
-        Query(description="""Ano de produção dos vinhos e tipos de vinhos"""),
-    ],
-):
+
+@app.get(URL_BASE + "/importacao", response_model=ImportacaoResponse)
+async def importacao(ano_subopcao_filter: T_AnoSubopcaoImportacaoFilter):
     """
     Endpoint para retornar dados de importação de derivados de uva.
     """
@@ -88,15 +73,11 @@ async def importacao(
             ano_subopcao_filter.ano, ano_subopcao_filter.subopcao
         )
     except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))
 
-@app.get(URL_BASE + "/exportacao")
-async def exportacao(
-    ano_subopcao_filter: Annotated[
-        AnoSubopcaoExportacaoFilterParams,
-        Query(description="""Ano de produção dos vinhos e tipos de vinhos"""),
-    ],
-):
+
+@app.get(URL_BASE + "/exportacao", response_model=ExportacaoResponse)
+async def exportacao(ano_subopcao_filter: T_AnoSubopcaoExportacaoFilter):
     """
     Endpoint para retornar dados de exportação de derivados de uva.
     """
@@ -105,4 +86,4 @@ async def exportacao(
             ano_subopcao_filter.ano, ano_subopcao_filter.subopcao
         )
     except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))

--- a/src/raspagem/comercializacao_raspagem.py
+++ b/src/raspagem/comercializacao_raspagem.py
@@ -9,7 +9,7 @@ class ComercializacaoRaspagem(VitiviniculturaRaspagem):
     da comercialização de vinhos, sucos e derivados do Rio Grande do Sul.
     """
 
-    def __init__(self, ano: int):
+    def __init__(self, ano: int, subopcao: str | None):
         super().__init__()
         self.ano = ano
         self.construir_url()

--- a/src/raspagem/producao_raspagem.py
+++ b/src/raspagem/producao_raspagem.py
@@ -9,7 +9,7 @@ class ProducaoRaspagem(VitiviniculturaRaspagem):
     da produção de vinhos, sucos e derivados do Rio Grande do Sul.
     """
 
-    def __init__(self, ano: int):
+    def __init__(self, ano: int, subopcao: str | None):
         super().__init__()
         self.ano = ano
         self.construir_url()

--- a/src/repositories/raw_repository.py
+++ b/src/repositories/raw_repository.py
@@ -14,7 +14,7 @@ from src.repositories.exceptions import (
 )
 
 class RawRepository:
-    def __init__(self, categoria: str, has_subopcao: bool):
+    def __init__(self, categoria: str, has_subopcao: bool = False):
         """
         Repositório genérico para qualquer endpoint de vitivinicultura.
         Guarda internamente o nome do endpoint (categoria) e se aceita subopcao.

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,0 +1,31 @@
+from typing import List
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+
+class Tipo(BaseModel):
+    nome: str
+    quantidade: int
+
+
+class Produto(BaseModel):
+    nome: str
+    quantidade: int
+    tipo: List[Tipo]
+
+
+class Producao(BaseModel):
+    produto: List[Produto]
+    total: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class BaseResponse(BaseModel):
+    source: str
+    fetched_at: datetime
+
+
+class ProducaoResponse(BaseResponse):
+    data: Producao
+

--- a/src/schemas/base_schema.py
+++ b/src/schemas/base_schema.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+class BaseResponse(BaseModel):
+    source: str
+    fetched_at: datetime

--- a/src/schemas/comercializacao_schema.py
+++ b/src/schemas/comercializacao_schema.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, ConfigDict
+from typing import List
+
+from src.schemas.base_schema import BaseResponse
+
+
+class TipoItem(BaseModel):
+    nome: str
+    quantidade: int
+
+
+class ProdutoItem(BaseModel):
+    nome: str
+    quantidade: int
+    tipo: List[TipoItem]
+
+
+class Comercializacao(BaseModel):
+    produto: List[ProdutoItem]
+    total: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ComercializacaoResponse(BaseResponse):
+    data: Comercializacao

--- a/src/schemas/exportacao_schema.py
+++ b/src/schemas/exportacao_schema.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, ConfigDict
+from typing import List
+
+from src.schemas.base_schema import BaseResponse
+
+
+class PaisItem(BaseModel):
+    pais: str
+    quantidade_kg: int
+    valor_us: int
+
+
+class TotalItem(BaseModel):
+    quantidade: int
+    valor: int
+
+
+class Exportacao(BaseModel):
+    paises: List[PaisItem]
+    total: TotalItem
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ExportacaoResponse(BaseResponse):
+    data: Exportacao

--- a/src/schemas/importacao_schema.py
+++ b/src/schemas/importacao_schema.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, ConfigDict
+from typing import List
+
+from src.schemas.base_schema import BaseResponse
+
+
+class PaisItem(BaseModel):
+    pais: str
+    quantidade_kg: int
+    valor_us: int
+
+
+class TotalItem(BaseModel):
+    quantidade: int
+    valor: int
+
+
+class Importacao(BaseModel):
+    paises: List[PaisItem]
+    total: TotalItem
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ImportacaoResponse(BaseResponse):
+    data: Importacao

--- a/src/schemas/processamento_schema.py
+++ b/src/schemas/processamento_schema.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, ConfigDict
+from typing import List
+
+from src.schemas.base_schema import BaseResponse
+
+
+class TipoItem(BaseModel):
+    nome: str
+    quantidade: int
+
+
+class CategoriaItem(BaseModel):
+    categoria: str
+    quantidade: int
+    tipos: List[TipoItem]
+
+
+class Processamento(BaseModel):
+    cultivar: List[CategoriaItem]
+    total: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ProcessamentoResponse(BaseResponse):
+    data: Processamento

--- a/src/schemas/producao_schema.py
+++ b/src/schemas/producao_schema.py
@@ -1,31 +1,26 @@
-from typing import List
-from datetime import datetime
 from pydantic import BaseModel, ConfigDict
+from typing import List
+
+from src.schemas.base_schema import BaseResponse
 
 
-class Tipo(BaseModel):
+class TipoItem(BaseModel):
     nome: str
     quantidade: int
 
 
-class Produto(BaseModel):
+class ProdutoItem(BaseModel):
     nome: str
     quantidade: int
-    tipo: List[Tipo]
+    tipo: List[TipoItem]
 
 
 class Producao(BaseModel):
-    produto: List[Produto]
+    produto: List[ProdutoItem]
     total: int
 
     model_config = ConfigDict(from_attributes=True)
 
 
-class BaseResponse(BaseModel):
-    source: str
-    fetched_at: datetime
-
-
 class ProducaoResponse(BaseResponse):
     data: Producao
-

--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -1,6 +1,6 @@
+import logging
 from abc import ABC, abstractmethod 
 from datetime import datetime, timezone
-from logging import Logger
 
 from src.raspagem.vitivinicultura_raspagem import VitiviniculturaRaspagem
 from src.raspagem.raspagem_exceptions import ErroParser, ErroRequisicao, TimeoutRequisicao
@@ -11,9 +11,9 @@ from src.schemas.base_schema import BaseResponse
 
 class BaseService(ABC):
 
-    def __init__(self, repository: RawRepository, logger: Logger):
+    def __init__(self, repository: RawRepository):
+        self.logger = logging.getLogger(self.__class__.__module__)
         self.repository = repository
-        self.logger = logger
 
     
     def get_por_ano(self, ano: int, subopcao: str | None = None) -> BaseResponse:

--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, Type, TypeVar
 
 from src.raspagem.raspagem_exceptions import ErroParser, ErroRequisicao, TimeoutRequisicao
 from src.repositories.exceptions import ErroConexaoBD, ErroConsultaBD, RegistroNaoEncontrado
-from src.schemas import BaseResponse
+from src.schemas.base_schema import BaseResponse
 
 
 T = TypeVar("T", bound=BaseResponse)

--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -1,0 +1,93 @@
+from abc import ABC, abstractmethod 
+from datetime import datetime, timezone
+from typing import Any, Generic, Type, TypeVar
+
+from src.raspagem.raspagem_exceptions import ErroParser, ErroRequisicao, TimeoutRequisicao
+from src.repositories.exceptions import ErroConexaoBD, ErroConsultaBD, RegistroNaoEncontrado
+from src.schemas import BaseResponse
+
+
+T = TypeVar("T", bound=BaseResponse)
+
+
+class BaseService(ABC, Generic[T]):
+
+    def __init__(self, response_cls: Type[T], raspagem_cls: Any, repository: Any, logger: Any):
+        self.response_cls = response_cls
+        self.raspagem_cls = raspagem_cls
+        self.repository = repository
+        self.logger = logger
+
+    
+    def get_por_ano(self, ano: int, subopcao: str | None = None) -> T:
+        dados = None
+        agora = None
+
+        try:
+            raspagem = self.raspagem_cls(ano, subopcao)
+            raspagem.buscar_html()
+            dados = raspagem.parser_html()
+            agora = datetime.now(timezone.utc)
+
+            try:
+                self.repository.salvar_ou_atualizar(dados, ano, subopcao)
+            except (ErroConexaoBD, ErroConsultaBD) as e:
+                self.logger.warning(
+                    f'[Cache/DB] Falha ao salvar/atualizar os dados no banco: {e}.'
+                    f' Dados continuarão sendo utilizados a partir da raspagem (site).'
+                )
+
+            return self.response_cls(
+                source = 'site',
+                fetched_at = agora,
+                data = self._transformar_json_para_modelo(dados)
+            )
+
+        except Exception as e:
+            self._log_exception(e, ano)
+
+            try:
+                registro = self.repository.get_por_ano(ano, subopcao)
+                if registro:
+                    return self.response_cls(
+                        source = 'banco',
+                        fetched_at = registro['fetched_at'],
+                        data = self._transformar_json_para_modelo(registro['data'])
+                    )
+
+            except RegistroNaoEncontrado as e:
+                self.logger.warning(
+                    f'[Fallback] Falha ao obter dados de {ano}: nenhuma resposta do site e cache '
+                    f' inexistente no banco de dados.')
+
+            except (ErroConexaoBD, ErroConsultaBD) as e:
+                self.logger.error(f'[Cache/DB] Falha ao salvar/atualizar os dados no banco: {e}.')
+                raise e
+
+
+    @abstractmethod
+    def _transformar_json_para_modelo(data: dict) -> Any:
+        pass
+
+
+    def _log_exception(self, e, ano):
+        if isinstance(e, TimeoutRequisicao):
+            self.logger.warning(
+                f'[Requisição] Timeout ao tentar obter dados de {ano} via site.' 
+                f' Utilizando fallback do banco de dados.'
+            )
+
+        elif isinstance(e, ErroRequisicao):
+            self.logger.warning(
+                f'[Requisição] Erro HTTP {e.status_code} ao acessar dados de {ano}.' 
+                f' Utilizando fallback do banco de dados.'
+            )
+        
+        elif isinstance(e, ErroParser):
+            self.logger.error(f'[Parser] Erro ao interpretar HTML para o ano {ano}: {e}.')
+        
+        else:
+            self.logger.exception(
+                f'[Erro] Erro inesperado durante o processamento de dados do ano {ano}.' 
+                f' Utilizando fallback para o banco de dados.'
+            )

--- a/src/services/comercializacao_service.py
+++ b/src/services/comercializacao_service.py
@@ -1,91 +1,40 @@
-# src/services/comercializacao_service.py
-"""
-Service para comercialização de vinhos, sucos e derivados
-do Rio Grande do Sul.
-"""
-
 import logging
-from datetime import datetime, timezone
+from pydantic import ValidationError
+
+from src.config.logging_config import configurar_logging
 from src.raspagem.comercializacao_raspagem import ComercializacaoRaspagem
 from src.repositories.comercializacao_repository import ComercializacaoRepository
-from src.raspagem.raspagem_exceptions import ErroRequisicao, TimeoutRequisicao, ErroParser
-from src.repositories.exceptions import (
-    ErroConexaoBD,
-    ErroConsultaBD,
-    RegistroNaoEncontrado,
-)
-from src.config.logging_config import configurar_logging
+from src.schemas.comercializacao_schema import (Comercializacao, ComercializacaoResponse,
+                                                ProdutoItem, TipoItem)
+from src.services.base_service import BaseService
+
 
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ComercializacaoService:
-    """
-    Service para comercialização de vinhos, sucos e derivados
-    do Rio Grande do Sul.
-    """
-
+class ComercializacaoService(BaseService[ComercializacaoResponse]):
     def __init__(self):
-        self.comercializacao_repository = ComercializacaoRepository()
+        super().__init__(
+            response_cls=ComercializacaoResponse,
+            raspagem_cls=ComercializacaoRaspagem,
+            repository=ComercializacaoRepository(),
+            logger=logger
+        )
 
-    def get_por_ano(self, ano: int) -> dict | str | None:
-        """
-        Retorna a comercialização de vinhos, sucos e derivados.
-        Tenta raspar; em falha, retorna o que estiver salvo.
-        Sempre com as chaves 'source', 'fetched_at' e 'data'.
-        """
-        dados = None
-        agora = None
-
-        try:
-            raspagem = ComercializacaoRaspagem(ano)
-            raspagem.buscar_html()
-            dados = raspagem.parser_html()
-            agora = datetime.now(timezone.utc)
-
-        except TimeoutRequisicao:
-            logger.warning(f"Timeout ao acessar dados do ano {ano}; usando dados locais.")
-        except ErroRequisicao as e:
-            logger.warning(f"Erro HTTP {e.status_code} ao acessar ano {ano}; usando dados locais.")
-        except ErroParser as e:
-            logger.error(f"Falha ao interpretar HTML do ano {ano}: {e}")
-        except Exception:
-            logger.exception(f"Erro inesperado ao processar dados de {ano}; usando dados locais.")
-
-        if dados:
-            try:
-                self.comercializacao_repository.salvar_ou_atualizar(dados, ano)
-            except (ErroConexaoBD, ErroConsultaBD) as e:
-                logger.warning(f"Impossível salvar cache: {e}; continuando com dados do site.")
-
-            return {
-                "source":     "site",
-                "fetched_at": agora,
-                "data":       dados
-            }
-
-        try:
-            registro = self.comercializacao_repository.get_por_ano(ano)
-        except RegistroNaoEncontrado:
-            logger.warning(f"Sem dados no site nem no banco para o ano {ano}.")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-        except (ErroConexaoBD, ErroConsultaBD) as e:
-            logger.error(f"Erro de persistência: {e}")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
+   
+    def _transformar_json_para_modelo(self, dados_json: dict) -> Comercializacao:
+        produtos = []
         
-        if not isinstance(registro, dict):
-            return registro
-        
-        return {
-            "source":     "banco",
-            "fetched_at": registro["fetched_at"],
-            "data":       registro["data"]
-        }
+        for item in dados_json["Produto"]:
+            nome_produto = next(k for k in item.keys() if k != "TIPOS")
+            qtd_produto = item[nome_produto]
+
+            tipos = []
+            for tipo in item.get("TIPOS", []):
+                nome_tipo = next(iter(tipo))
+                qtd_tipo = tipo[nome_tipo]
+                tipos.append(TipoItem(nome=nome_tipo, quantidade=qtd_tipo))
+
+            produtos.append(ProdutoItem(nome=nome_produto, quantidade=qtd_produto, tipo=tipos))
+            
+        return Comercializacao(produto=produtos, total=dados_json["Total"])

--- a/src/services/comercializacao_service.py
+++ b/src/services/comercializacao_service.py
@@ -1,7 +1,5 @@
-import logging
 from datetime import datetime
 
-from src.config.logging_config import configurar_logging
 from src.raspagem.comercializacao_raspagem import ComercializacaoRaspagem
 from src.repositories.comercializacao_repository import ComercializacaoRepository
 from src.schemas.comercializacao_schema import (Comercializacao, ComercializacaoResponse,
@@ -9,14 +7,13 @@ from src.schemas.comercializacao_schema import (Comercializacao, Comercializacao
 from src.services.base_service import BaseService
 
 
-configurar_logging()
-logger = logging.getLogger(__name__)
-
-
 class ComercializacaoService(BaseService):
+    """
+    Service para comercialização de vinhos, sucos e derivados do Rio Grande do Sul.
+    """
 
     def __init__(self):
-        super().__init__(repository=ComercializacaoRepository(), logger=logger)
+        super().__init__(repository=ComercializacaoRepository())
 
 
     def get_raspagem(self, ano: int, subopcao: str) -> ComercializacaoRaspagem:

--- a/src/services/comercializacao_service.py
+++ b/src/services/comercializacao_service.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import ValidationError
+from datetime import datetime
 
 from src.config.logging_config import configurar_logging
 from src.raspagem.comercializacao_raspagem import ComercializacaoRaspagem
@@ -12,16 +12,25 @@ from src.services.base_service import BaseService
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ComercializacaoService(BaseService[ComercializacaoResponse]):
+
+class ComercializacaoService(BaseService):
+
     def __init__(self):
-        super().__init__(
-            response_cls=ComercializacaoResponse,
-            raspagem_cls=ComercializacaoRaspagem,
-            repository=ComercializacaoRepository(),
-            logger=logger
+        super().__init__(repository=ComercializacaoRepository(), logger=logger)
+
+
+    def get_raspagem(self, ano: int, subopcao: str) -> ComercializacaoRaspagem:
+        return ComercializacaoRaspagem(ano, subopcao)
+    
+
+    def get_reponse(self, source: str, fetched_at: datetime, data: dict) -> ComercializacaoResponse:
+        return ComercializacaoResponse(
+            source = source,
+            fetched_at = fetched_at, 
+            data = self._transformar_json_para_modelo(data)
         )
 
-   
+
     def _transformar_json_para_modelo(self, dados_json: dict) -> Comercializacao:
         produtos = []
         

--- a/src/services/exportacao_service.py
+++ b/src/services/exportacao_service.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from src.config.logging_config import configurar_logging
 from src.raspagem.exportacao_raspagem import ExportacaoRaspagem
@@ -10,18 +11,22 @@ from src.services.base_service import BaseService
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ExportacaoService(BaseService[ExportacaoResponse]):
+
+class ExportacaoService(BaseService):
     """
     Service para exportação de vinhos, sucos e derivados do Rio Grande do Sul.
     """
     def __init__(self):
-        super().__init__(
-            response_cls=ExportacaoResponse,
-            raspagem_cls=ExportacaoRaspagem,
-            repository=ExportacaoRepository(),
-            logger=logger
+        super().__init__(repository=ExportacaoRepository(), logger=logger)
+
+
+    def get_raspagem(self, ano: int, subopcao: str) -> ExportacaoRaspagem:
+        return ExportacaoRaspagem(ano, subopcao)
+
+    
+    def get_reponse(self, source: str, fetched_at: datetime, data: dict) -> ExportacaoResponse:
+        return ExportacaoResponse(
+            source = source,
+            fetched_at = fetched_at, 
+            data = Exportacao(**data)
         )
-
-
-    def _transformar_json_para_modelo(self, dados_json: dict) -> Exportacao:
-        return Exportacao(**dados_json)

--- a/src/services/exportacao_service.py
+++ b/src/services/exportacao_service.py
@@ -1,89 +1,27 @@
-# src/services/exportacao_service.py
-"""
-Service para exportação de vinhos, sucos e derivados
-do Rio Grande do Sul.
-"""
-
 import logging
-from datetime import datetime, timezone
+
+from src.config.logging_config import configurar_logging
 from src.raspagem.exportacao_raspagem import ExportacaoRaspagem
 from src.repositories.exportacao_repository import ExportacaoRepository
-from src.raspagem.raspagem_exceptions import ErroRequisicao, TimeoutRequisicao, ErroParser
-from src.repositories.exceptions import (
-    ErroConexaoBD,
-    ErroConsultaBD,
-    RegistroNaoEncontrado,
-)
-from src.config.logging_config import configurar_logging
+from src.schemas.exportacao_schema import Exportacao, ExportacaoResponse
+from src.services.base_service import BaseService
+
 
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ExportacaoService:
+class ExportacaoService(BaseService[ExportacaoResponse]):
     """
-    Service para exportação de vinhos, sucos e derivados
-    do Rio Grande do Sul.
+    Service para exportação de vinhos, sucos e derivados do Rio Grande do Sul.
     """
     def __init__(self):
-        self.exportacao_repository = ExportacaoRepository()
+        super().__init__(
+            response_cls=ExportacaoResponse,
+            raspagem_cls=ExportacaoRaspagem,
+            repository=ExportacaoRepository(),
+            logger=logger
+        )
 
-    def get_por_ano(self, ano: int, subopcao: str) -> dict | str | None:
-        """
-        Retorna a exportação de vinhos, sucos e derivados
-        Tenta raspar; em falha, retorna o que estiver salvo.
-        Sempre com as chaves 'source', 'fetched_at' e 'data'.
-        """
-        dados = None
-        agora = None
-        try:
-            exportacao_raspagem = ExportacaoRaspagem(ano, subopcao)
-            exportacao_raspagem.buscar_html()
-            dados = exportacao_raspagem.parser_html()
-            agora = datetime.now(timezone.utc)
 
-        except TimeoutRequisicao:
-            logger.warning(f"Timeout ao acessar dados do ano {ano}; usando dados locais.")
-        except ErroRequisicao as e:
-            logger.warning(f"Erro HTTP {e.status_code} ao acessar ano {ano}; usando dados locais.")
-        except ErroParser as e:
-            logger.error(f"Falha ao interpretar HTML do ano {ano}: {e}")
-        except Exception:
-            logger.exception(f"Erro inesperado ao processar dados de {ano}; usando dados locais.")
-
-        if dados:
-            try:
-                self.exportacao_repository.salvar_ou_atualizar(dados, ano, subopcao)
-            except (ErroConexaoBD, ErroConsultaBD) as e:
-                logger.warning(f"Impossível salvar cache: {e}; continuando com dados do site.")
-
-            return {
-                "source":     "site",
-                "fetched_at": agora,
-                "data":       dados
-            }
-                    
-        try:
-            registro = self.exportacao_repository.get_por_ano(ano, subopcao)
-        except RegistroNaoEncontrado:
-            logger.warning(f"Sem dados no site nem no banco para o ano {ano}.")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-        except (ErroConexaoBD, ErroConsultaBD) as e:
-            logger.error(f"Erro de persistência: {e}")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-
-        if not isinstance(registro, dict):
-            return registro
-        
-        return {
-            "source":     "banco",
-            "fetched_at": registro["fetched_at"],
-            "data":       registro["data"]
-        }
+    def _transformar_json_para_modelo(self, dados_json: dict) -> Exportacao:
+        return Exportacao(**dados_json)

--- a/src/services/exportacao_service.py
+++ b/src/services/exportacao_service.py
@@ -1,15 +1,9 @@
-import logging
 from datetime import datetime
 
-from src.config.logging_config import configurar_logging
 from src.raspagem.exportacao_raspagem import ExportacaoRaspagem
 from src.repositories.exportacao_repository import ExportacaoRepository
 from src.schemas.exportacao_schema import Exportacao, ExportacaoResponse
 from src.services.base_service import BaseService
-
-
-configurar_logging()
-logger = logging.getLogger(__name__)
 
 
 class ExportacaoService(BaseService):
@@ -17,7 +11,7 @@ class ExportacaoService(BaseService):
     Service para exportação de vinhos, sucos e derivados do Rio Grande do Sul.
     """
     def __init__(self):
-        super().__init__(repository=ExportacaoRepository(), logger=logger)
+        super().__init__(repository=ExportacaoRepository())
 
 
     def get_raspagem(self, ano: int, subopcao: str) -> ExportacaoRaspagem:

--- a/src/services/importacao_service.py
+++ b/src/services/importacao_service.py
@@ -1,24 +1,17 @@
-import logging
 from datetime import datetime
 
-from src.config.logging_config import configurar_logging
 from src.raspagem.importacao_raspagem import ImportacaoRaspagem
 from src.repositories.importacao_repository import ImportacaoRepository
 from src.schemas.importacao_schema import Importacao, ImportacaoResponse
 from src.services.base_service import BaseService
 
 
-configurar_logging()
-logger = logging.getLogger(__name__)
-
-
 class ImportacaoService(BaseService):
     """
     Service para importação de vinhos, sucos e derivados do Rio Grande do Sul.
     """
-
     def __init__(self):
-        super().__init__(repository=ImportacaoRepository(), logger=logger)
+        super().__init__(repository=ImportacaoRepository())
 
 
     def get_raspagem(self, ano: int, subopcao: str) -> ImportacaoRaspagem:

--- a/src/services/importacao_service.py
+++ b/src/services/importacao_service.py
@@ -1,90 +1,29 @@
-# src/services/importacao_service.py
-"""
-Service para importação de vinhos, sucos e derivados
-do Rio Grande do Sul.
-"""
-
 import logging
-from datetime import datetime, timezone
+
+from src.config.logging_config import configurar_logging
 from src.raspagem.importacao_raspagem import ImportacaoRaspagem
 from src.repositories.importacao_repository import ImportacaoRepository
-from src.raspagem.raspagem_exceptions import ErroRequisicao, TimeoutRequisicao, ErroParser
-from src.repositories.exceptions import (
-    ErroConexaoBD,
-    ErroConsultaBD,
-    RegistroNaoEncontrado,
-)
-from src.config.logging_config import configurar_logging
+from src.schemas.importacao_schema import Importacao, ImportacaoResponse
+from src.services.base_service import BaseService
+
 
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ImportacaoService:
+
+class ImportacaoService(BaseService[ImportacaoResponse]):
     """
-    Service para importação de vinhos, sucos e derivados
-    do Rio Grande do Sul.
+    Service para importação de vinhos, sucos e derivados do Rio Grande do Sul.
     """
 
     def __init__(self):
-        self.importacao_repository = ImportacaoRepository()
+        super().__init__(
+            response_cls=ImportacaoResponse,
+            raspagem_cls=ImportacaoRaspagem,
+            repository=ImportacaoRepository(),
+            logger=logger
+        )
 
-    def get_por_ano(self, ano: int, subopcao: str) -> dict | str | None:
-        """
-        Retorna a importação de vinhos, sucos e derivados
-        Tenta raspar; em falha, retorna o que estiver salvo.
-        Sempre com as chaves 'source', 'fetched_at' e 'data'.
-        """
-        dados = None
-        agora = None
-        try:
-            importacao_raspagem = ImportacaoRaspagem(ano, "subopt_01")
-            importacao_raspagem.buscar_html()
-            dados = importacao_raspagem.parser_html()
-            agora = datetime.now(timezone.utc)
 
-        except TimeoutRequisicao:
-            logger.warning(f"Timeout ao acessar dados do ano {ano}; usando dados locais.")
-        except ErroRequisicao as e:
-            logger.warning(f"Erro HTTP {e.status_code} ao acessar ano {ano}; usando dados locais.")
-        except ErroParser as e:
-            logger.error(f"Falha ao interpretar HTML do ano {ano}: {e}")
-        except Exception:
-            logger.exception(f"Erro inesperado ao processar dados de {ano}; usando dados locais.")
-
-        if dados:
-            try:
-                self.importacao_repository.salvar_ou_atualizar(dados, ano, subopcao)
-            except (ErroConexaoBD, ErroConsultaBD) as e:
-                logger.warning(f"Impossível salvar cache: {e}; continuando com dados do site.")
-
-            return {
-                "source":     "site",
-                "fetched_at": agora,
-                "data":       dados
-            }
-
-        try:
-            registro = self.importacao_repository.get_por_ano(ano, subopcao)
-        except RegistroNaoEncontrado:
-            logger.warning(f"Sem dados no site nem no banco para o ano {ano}.")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-        except (ErroConexaoBD, ErroConsultaBD) as e:
-            logger.error(f"Erro de persistência: {e}")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-        
-        if not isinstance(registro, dict):
-            return registro
-        
-        return {
-            "source":     "banco",
-            "fetched_at": registro["fetched_at"],
-            "data":       registro["data"]
-        }
+    def _transformar_json_para_modelo(self, dados_json: dict) -> Importacao:
+        return Importacao(**dados_json)

--- a/src/services/importacao_service.py
+++ b/src/services/importacao_service.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from src.config.logging_config import configurar_logging
 from src.raspagem.importacao_raspagem import ImportacaoRaspagem
@@ -11,19 +12,22 @@ configurar_logging()
 logger = logging.getLogger(__name__)
 
 
-class ImportacaoService(BaseService[ImportacaoResponse]):
+class ImportacaoService(BaseService):
     """
     Service para importação de vinhos, sucos e derivados do Rio Grande do Sul.
     """
 
     def __init__(self):
-        super().__init__(
-            response_cls=ImportacaoResponse,
-            raspagem_cls=ImportacaoRaspagem,
-            repository=ImportacaoRepository(),
-            logger=logger
+        super().__init__(repository=ImportacaoRepository(), logger=logger)
+
+
+    def get_raspagem(self, ano: int, subopcao: str) -> ImportacaoRaspagem:
+        return ImportacaoRaspagem(ano, subopcao)
+
+
+    def get_reponse(self, source: str, fetched_at: datetime, data: dict) -> ImportacaoResponse:
+        return ImportacaoResponse(
+            source = source, 
+            fetched_at = fetched_at, 
+            data = Importacao(**data)
         )
-
-
-    def _transformar_json_para_modelo(self, dados_json: dict) -> Importacao:
-        return Importacao(**dados_json)

--- a/src/services/processamento_service.py
+++ b/src/services/processamento_service.py
@@ -1,7 +1,5 @@
-import logging
 from datetime import datetime
 
-from src.config.logging_config import configurar_logging
 from src.raspagem.processamento_raspagem import ProcessamentoRaspagem
 from src.repositories.processamento_repository import ProcessamentoRepository
 from src.schemas.processamento_schema import (CategoriaItem, Processamento,
@@ -9,17 +7,12 @@ from src.schemas.processamento_schema import (CategoriaItem, Processamento,
 from src.services.base_service import BaseService
 
 
-configurar_logging()
-logger = logging.getLogger(__name__)
-
-
 class ProcessamentoService(BaseService):
     """
     Service para Processamento de uvas do Rio Grande do Sul.
     """
-
     def __init__(self):
-        super().__init__(repository=ProcessamentoRepository(), logger=logger)
+        super().__init__(repository=ProcessamentoRepository())
 
     
     def get_raspagem(self, ano: int, subopcao: str) -> ProcessamentoRaspagem:

--- a/src/services/processamento_service.py
+++ b/src/services/processamento_service.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from src.config.logging_config import configurar_logging
 from src.raspagem.processamento_raspagem import ProcessamentoRaspagem
@@ -11,17 +12,25 @@ from src.services.base_service import BaseService
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ProcessamentoService(BaseService[ProcessamentoResponse]):
+
+class ProcessamentoService(BaseService):
     """
     Service para Processamento de uvas do Rio Grande do Sul.
     """
 
     def __init__(self):
-        super().__init__(
-            response_cls=ProcessamentoResponse,
-            raspagem_cls=ProcessamentoRaspagem,
-            repository=ProcessamentoRepository(),
-            logger=logger
+        super().__init__(repository=ProcessamentoRepository(), logger=logger)
+
+    
+    def get_raspagem(self, ano: int, subopcao: str) -> ProcessamentoRaspagem:
+        return ProcessamentoRaspagem(ano, subopcao)
+    
+
+    def get_reponse(self, source: str, fetched_at: datetime, data: dict) -> ProcessamentoResponse:
+        return ProcessamentoResponse(
+            source = source,
+            fetched_at = fetched_at, 
+            data = self._transformar_json_para_modelo(data)
         )
 
 

--- a/src/services/producao_service.py
+++ b/src/services/producao_service.py
@@ -1,21 +1,17 @@
-import logging
 from datetime import datetime
 
-from src.config.logging_config import configurar_logging
 from src.raspagem.producao_raspagem import ProducaoRaspagem
 from src.repositories.producao_repository import ProducaoRepository
 from src.schemas.producao_schema import Producao, ProducaoResponse, ProdutoItem, TipoItem
 from src.services.base_service import BaseService
 
 
-configurar_logging()
-logger = logging.getLogger(__name__)
-
-
 class ProducaoService(BaseService):
-
+    """
+    Service para a prodrução de vinhos, sucos e derivados do Rio Grande do Sul.
+    """
     def __init__(self):
-        super().__init__(repository=ProducaoRepository(), logger=logger)
+        super().__init__(repository=ProducaoRepository())
 
 
     def get_raspagem(self, ano: int, subopcao: str) -> ProducaoRaspagem:

--- a/src/services/producao_service.py
+++ b/src/services/producao_service.py
@@ -3,7 +3,7 @@ import logging
 from src.config.logging_config import configurar_logging
 from src.raspagem.producao_raspagem import ProducaoRaspagem
 from src.repositories.producao_repository import ProducaoRepository
-from src.schemas import Producao, ProducaoResponse, Produto, Tipo
+from src.schemas.producao_schema import Producao, ProducaoResponse, ProdutoItem, TipoItem
 from src.services.base_service import BaseService
 
 
@@ -35,9 +35,9 @@ class ProducaoService(BaseService[ProducaoResponse]):
             for tipo in item.get("TIPOS", []):
                 nome_tipo = next(iter(tipo))
                 qtd_tipo = tipo[nome_tipo]
-                tipos.append(Tipo(nome=nome_tipo, quantidade=qtd_tipo))
+                tipos.append(TipoItem(nome=nome_tipo, quantidade=qtd_tipo))
 
-            produtos.append(Produto(
+            produtos.append(ProdutoItem(
                                 nome=nome_produto,
                                 quantidade=qtd_produto,
                                 tipo=tipos))

--- a/src/services/producao_service.py
+++ b/src/services/producao_service.py
@@ -1,90 +1,45 @@
-# src/services/producao_service.py
-"""
-Service para Produção de vinhos, sucos e derivados
-do Rio Grande do Sul.
-"""
-
 import logging
-from datetime import datetime, timezone
+
+from src.config.logging_config import configurar_logging
 from src.raspagem.producao_raspagem import ProducaoRaspagem
 from src.repositories.producao_repository import ProducaoRepository
-from src.raspagem.raspagem_exceptions import ErroRequisicao, TimeoutRequisicao, ErroParser
-from src.repositories.exceptions import (
-    ErroConexaoBD,
-    ErroConsultaBD,
-    RegistroNaoEncontrado,
-)
-from src.config.logging_config import configurar_logging
+from src.schemas import Producao, ProducaoResponse, Produto, Tipo
+from src.services.base_service import BaseService
+
 
 configurar_logging()
 logger = logging.getLogger(__name__)
 
-class ProducaoService:
-    """
-    Service para produção de vinhos, sucos e derivados
-    do Rio Grande do Sul.
-    """
+
+class ProducaoService(BaseService[ProducaoResponse]):
 
     def __init__(self):
-        self.producao_repository = ProducaoRepository()
+        super().__init__(
+            response_cls=ProducaoResponse,
+            raspagem_cls=ProducaoRaspagem,
+            repository=ProducaoRepository(),
+            logger=logger
+        )
 
-    def get_por_ano(self, ano: int) -> dict | str | None:
-        """
-        Retorna a produção de vinhos, sucos e derivados.
-        Tenta raspar; em falha ou sem dados, retorna o que estiver salvo,
-        sempre com as chaves 'source', 'fetched_at' e 'data'.
-        """
-        dados = None
-        agora = None
-        try:
-            raspagem = ProducaoRaspagem(ano)
-            raspagem.buscar_html()
-            dados = raspagem.parser_html()
-            agora = datetime.now(timezone.utc)
+       
+    def _transformar_json_para_modelo(self, dados_json: dict) -> Producao:
+        produtos = []
 
-        except TimeoutRequisicao:
-            logger.warning(f"Timeout ao acessar dados do ano {ano}; usando dados locais.")
-        except ErroRequisicao as e:
-            logger.warning(f"Erro HTTP {e.status_code} ao acessar ano {ano}; usando dados locais.")
-        except ErroParser as e:
-            logger.error(f"Falha ao interpretar HTML do ano {ano}: {e}")
-        except Exception:
-            logger.exception(f"Erro inesperado ao processar dados de {ano}; usando dados locais.")
+        for item in dados_json["Produto"]:
+            # Extrai o nome e a quantidade do produto (chave única por item)
 
-        if dados:
-            try:
-                self.producao_repository.salvar_ou_atualizar(dados, ano)
-            except (ErroConexaoBD, ErroConsultaBD) as e:
-                logger.warning(f"Impossível salvar cache: {e}; continuando com dados do site.")
+            nome_produto = next(k for k in item.keys() if k != "TIPOS")
+            qtd_produto = item[nome_produto]
 
-            return {
-                "source":     "site",
-                "fetched_at": agora,
-                "data":       dados
-            }
+            tipos = []
+            for tipo in item.get("TIPOS", []):
+                nome_tipo = next(iter(tipo))
+                qtd_tipo = tipo[nome_tipo]
+                tipos.append(Tipo(nome=nome_tipo, quantidade=qtd_tipo))
 
-        try:
-            registro = self.producao_repository.get_por_ano(ano)
-        except RegistroNaoEncontrado:
-            logger.warning(f"Sem dados no site nem no banco para o ano {ano}.")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-        except (ErroConexaoBD, ErroConsultaBD) as e:
-            logger.error(f"Erro de persistência: {e}")
-            return {
-                "source":     "api",
-                "fetched_at": None,
-                "data":       None
-            }
-        
-        if not isinstance(registro, dict):
-            return registro
-        
-        return {
-            "source":     "banco",
-            "fetched_at": registro["fetched_at"],
-            "data":       registro["data"]
-        }
+            produtos.append(Produto(
+                                nome=nome_produto,
+                                quantidade=qtd_produto,
+                                tipo=tipos))
+
+        return Producao(produto=produtos, total=dados_json["Total"])

--- a/src/services/producao_service.py
+++ b/src/services/producao_service.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from src.config.logging_config import configurar_logging
 from src.raspagem.producao_raspagem import ProducaoRaspagem
@@ -11,17 +12,24 @@ configurar_logging()
 logger = logging.getLogger(__name__)
 
 
-class ProducaoService(BaseService[ProducaoResponse]):
+class ProducaoService(BaseService):
 
     def __init__(self):
-        super().__init__(
-            response_cls=ProducaoResponse,
-            raspagem_cls=ProducaoRaspagem,
-            repository=ProducaoRepository(),
-            logger=logger
+        super().__init__(repository=ProducaoRepository(), logger=logger)
+
+
+    def get_raspagem(self, ano: int, subopcao: str) -> ProducaoRaspagem:
+        return ProducaoRaspagem(ano, subopcao)
+
+
+    def get_reponse(self, source: str, fetched_at: datetime, data: dict) -> ProducaoResponse:
+        return ProducaoResponse(
+            source = source,
+            fetched_at = fetched_at, 
+            data = self._transformar_json_para_modelo(data)
         )
 
-       
+
     def _transformar_json_para_modelo(self, dados_json: dict) -> Producao:
         produtos = []
 


### PR DESCRIPTION
:memo: Descrição

Este pull request implementa a documentação automática da API utilizando o Swagger com suporte ao Pydantic, conforme descrito na issue #60. As principais ações realizadas incluem:

    Definição de modelos de entrada e saída com Pydantic para validação e tipagem;

    Anotação dos endpoints com tipos explícitos, permitindo a geração automática da documentação Swagger;

    Ajustes na configuração do FastAPI (ou framework utilizado) para exibir corretamente os schemas gerados;

    Verificação e validação da documentação gerada via Swagger UI.

:mag: Como testar

    Inicie a aplicação localmente.

    Acesse a interface Swagger via /docs ou Redoc via /redoc.

    Verifique se todos os endpoints estão documentados com:

        Parâmetros de entrada bem definidos;

        Respostas com estrutura e status adequados;

:link: Issue relacionada

Closes #60